### PR TITLE
:sparkles: 일일 조회수 api 개발

### DIFF
--- a/src/main/java/com/example/userservice/UserServiceApplication.java
+++ b/src/main/java/com/example/userservice/UserServiceApplication.java
@@ -9,6 +9,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.client.RestTemplate;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableEurekaClient
 @EnableFeignClients
@@ -26,5 +29,11 @@ public class UserServiceApplication {
     @LoadBalanced
     public RestTemplate getRestTemplate(){
         return new RestTemplate();
+    }
+
+
+    @PostConstruct
+    public void started() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
     }
 }

--- a/src/main/java/com/example/userservice/domain/visitor/controller/VisitorController.java
+++ b/src/main/java/com/example/userservice/domain/visitor/controller/VisitorController.java
@@ -35,11 +35,19 @@ public class VisitorController {
     }
 
     @GetMapping(value = "")
-    public ResponseEntity<?> visitorCheck() {
+    public ResponseEntity<?> toDayVisitorCheck() {
         log.info("방문자 수 get");
         Long viewCount = visitorService.readHomeViewCount();
         return new ResponseEntity<>(
-                new CommonResDto<>(1,"방문자 확인하기",viewCount), HttpStatus.OK
+                new CommonResDto<>(1,"일일 방문자 확인하기",viewCount), HttpStatus.OK
+        );
+    }
+    @GetMapping(value = "/total-view")
+    public ResponseEntity<?> totalVisitorCheck() {
+        log.info("방문자 수 get");
+        Long viewCount = visitorService.readHomeTotalViewCount();
+        return new ResponseEntity<>(
+                new CommonResDto<>(1,"총 방문자 확인하기",viewCount), HttpStatus.OK
         );
     }
 

--- a/src/main/java/com/example/userservice/domain/visitor/controller/VisitorController.java
+++ b/src/main/java/com/example/userservice/domain/visitor/controller/VisitorController.java
@@ -1,0 +1,46 @@
+package com.example.userservice.domain.visitor.controller;
+
+import com.example.userservice.domain.visitor.service.VisitorService;
+import com.example.userservice.global.common.CommonResDto;
+import com.example.userservice.global.helper.IpHelper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/v1/visitor")
+public class VisitorController {
+
+    private final VisitorService visitorService;
+
+    // 원래는 ip로 확인해주는 것이 맞지만 현재 istio 내부에서 계속해서 x forwared 값을 127.0.0.6으로
+    //반환을 해주기 때문에 ip는 중복체크하지않고 호출하면 방문자 수 계속 늘려주는 방식으로 결정한다.
+    @PostMapping(value = "")
+    public ResponseEntity<?> increaseVisitor(HttpServletRequest request) {
+        log.info("방문자 수 post");
+        String clientIpAddr = IpHelper.getClientIpAddr(request);
+        visitorService.increaseHomeViewCount(clientIpAddr);
+        return new ResponseEntity<>(
+                new CommonResDto<>(1,"방문자 카운트 증가",""), HttpStatus.OK
+        );
+    }
+
+    @GetMapping(value = "")
+    public ResponseEntity<?> visitorCheck() {
+        log.info("방문자 수 get");
+        Long viewCount = visitorService.readHomeViewCount();
+        return new ResponseEntity<>(
+                new CommonResDto<>(1,"방문자 확인하기",viewCount), HttpStatus.OK
+        );
+    }
+
+}

--- a/src/main/java/com/example/userservice/domain/visitor/entity/Visitor.java
+++ b/src/main/java/com/example/userservice/domain/visitor/entity/Visitor.java
@@ -1,0 +1,31 @@
+package com.example.userservice.domain.visitor.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "Visitor")
+public class Visitor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    private long count;
+
+
+    @Builder
+    public Visitor(long count) {
+        this.count = count;
+    }
+
+    public void plus(long viewCount) {
+        this.count += viewCount;
+    }
+}

--- a/src/main/java/com/example/userservice/domain/visitor/repository/VisitorRepository.java
+++ b/src/main/java/com/example/userservice/domain/visitor/repository/VisitorRepository.java
@@ -1,0 +1,8 @@
+package com.example.userservice.domain.visitor.repository;
+
+import com.example.userservice.domain.visitor.entity.Visitor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VisitorRepository extends JpaRepository<Visitor,Long> {
+
+}

--- a/src/main/java/com/example/userservice/domain/visitor/service/VisitorService.java
+++ b/src/main/java/com/example/userservice/domain/visitor/service/VisitorService.java
@@ -1,0 +1,8 @@
+package com.example.userservice.domain.visitor.service;
+
+public interface VisitorService {
+
+    void increaseHomeViewCount(String ipAddress);
+
+    Long readHomeViewCount();
+}

--- a/src/main/java/com/example/userservice/domain/visitor/service/VisitorService.java
+++ b/src/main/java/com/example/userservice/domain/visitor/service/VisitorService.java
@@ -5,4 +5,7 @@ public interface VisitorService {
     void increaseHomeViewCount(String ipAddress);
 
     Long readHomeViewCount();
+
+    Long readHomeTotalViewCount();
+
 }

--- a/src/main/java/com/example/userservice/domain/visitor/service/impl/VisitorServiceImpl.java
+++ b/src/main/java/com/example/userservice/domain/visitor/service/impl/VisitorServiceImpl.java
@@ -1,0 +1,47 @@
+package com.example.userservice.domain.visitor.service.impl;
+
+
+import com.example.userservice.domain.visitor.entity.Visitor;
+import com.example.userservice.domain.visitor.repository.VisitorRepository;
+import com.example.userservice.domain.visitor.service.VisitorService;
+import com.example.userservice.domain.visitor.util.ViewCountUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VisitorServiceImpl implements VisitorService {
+
+    private final ViewCountUtil viewCountUtil;
+    private final VisitorRepository visitorRepository;
+    private final static LocalDateTime dateTime = LocalDateTime.now();
+    private final static int YEAR = dateTime.getYear();
+    private final static int MONTH = dateTime.getMonthValue();
+    private final static int DAY = dateTime.getDayOfMonth();
+
+    @Override
+    @Transactional
+    public void increaseHomeViewCount(String ipAddress) {
+//        if(!viewCountUtil.isDuplicatedAccess(ipAddress, "Home")) { // 중복된 값이 있는지 확인
+        viewCountUtil.increaseData("viewCount_Home_1"+YEAR+MONTH+DAY); // 해당 키에 data값 1씩 증가
+//        viewCountUtil.setDuplicateAccess(ipAddress, "Home"); //1일 동안 해당 아이피 유지
+        Long viewCount = viewCountUtil.getViewCount("viewCount_Home_1"+YEAR+MONTH+DAY);
+        Visitor visitor = Visitor.builder()
+                .count(viewCount)
+                .build();
+        visitorRepository.save(visitor);
+//        }
+    }
+
+    @Override
+    public Long readHomeViewCount() {
+        Long viewCount = viewCountUtil.getViewCount("viewCount_Home_1"+YEAR+MONTH+DAY);
+        return viewCount;
+    }
+}

--- a/src/main/java/com/example/userservice/domain/visitor/service/impl/VisitorServiceImpl.java
+++ b/src/main/java/com/example/userservice/domain/visitor/service/impl/VisitorServiceImpl.java
@@ -29,11 +29,12 @@ public class VisitorServiceImpl implements VisitorService {
     @Transactional
     public void increaseHomeViewCount(String ipAddress) {
 //        if(!viewCountUtil.isDuplicatedAccess(ipAddress, "Home")) { // 중복된 값이 있는지 확인
+        viewCountUtil.increaseData("ViewCount_Home_Total"); // 해당 키에 data값 1씩 증가
         viewCountUtil.increaseData("viewCount_Home_1"+YEAR+MONTH+DAY); // 해당 키에 data값 1씩 증가
 //        viewCountUtil.setDuplicateAccess(ipAddress, "Home"); //1일 동안 해당 아이피 유지
-        Long viewCount = viewCountUtil.getViewCount("viewCount_Home_1"+YEAR+MONTH+DAY);
+        Long totalViewCount = viewCountUtil.getViewCount("ViewCount_Home_Total");
         Visitor visitor = Visitor.builder()
-                .count(viewCount)
+                .count(totalViewCount)
                 .build();
         visitorRepository.save(visitor);
 //        }
@@ -42,6 +43,12 @@ public class VisitorServiceImpl implements VisitorService {
     @Override
     public Long readHomeViewCount() {
         Long viewCount = viewCountUtil.getViewCount("viewCount_Home_1"+YEAR+MONTH+DAY);
+        return viewCount;
+    }
+
+    @Override
+    public Long readHomeTotalViewCount() {
+        Long viewCount = viewCountUtil.getViewCount("ViewCount_Home_Total");
         return viewCount;
     }
 }

--- a/src/main/java/com/example/userservice/domain/visitor/util/ViewCountUtil.java
+++ b/src/main/java/com/example/userservice/domain/visitor/util/ViewCountUtil.java
@@ -24,7 +24,11 @@ public class ViewCountUtil {
     }
 
     public Long getViewCount(String key) {
-        return Long.parseLong((String) visitorRedisUtil.getData(key));
+        if(visitorRedisUtil.getData(key)==null){
+            return 0L;
+        }else{
+            return Long.parseLong((String) visitorRedisUtil.getData(key));
+        }
     }
 
     public Set<String> getKeySet(String domain) {

--- a/src/main/java/com/example/userservice/domain/visitor/util/ViewCountUtil.java
+++ b/src/main/java/com/example/userservice/domain/visitor/util/ViewCountUtil.java
@@ -1,0 +1,42 @@
+package com.example.userservice.domain.visitor.util;
+
+import com.example.userservice.global.config.redis.util.VisitorRedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@RequiredArgsConstructor
+@Component
+public class ViewCountUtil {
+
+    private final VisitorRedisUtil visitorRedisUtil;
+
+
+    public boolean isDuplicatedAccess(String ipAddress, String domainName) {
+        return visitorRedisUtil.getData(ipAddress + "_" + domainName) != null;
+    }
+
+    public void setDuplicateAccess(String ipAddress, String domainName){
+        visitorRedisUtil.setData(ipAddress + "_" + domainName, 1L, 1L, TimeUnit.DAYS);
+    }
+
+    public Long getViewCount(String key) {
+        return Long.parseLong((String) visitorRedisUtil.getData(key));
+    }
+
+    public Set<String> getKeySet(String domain) {
+        return visitorRedisUtil.getKeySet(domain);
+    }
+
+    public void deleteData(String key) {
+        visitorRedisUtil.deleteData(key);
+    }
+
+    public void increaseData(String key) {
+        visitorRedisUtil.increaseData(key);
+    }
+
+}

--- a/src/main/java/com/example/userservice/global/config/redis/EmbeddedRedisConfig.java
+++ b/src/main/java/com/example/userservice/global/config/redis/EmbeddedRedisConfig.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.util.StringUtils;
 import redis.embedded.RedisServer;
 
@@ -22,6 +23,15 @@ public class EmbeddedRedisConfig {
     private int redisPort;
 
     private RedisServer redisServer;
+
+    private final StringRedisTemplate redisTemplate;
+
+    public EmbeddedRedisConfig(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+
+
 
     @PostConstruct
     public void startRedis() throws IOException {

--- a/src/main/java/com/example/userservice/global/config/redis/util/VisitorRedisUtil.java
+++ b/src/main/java/com/example/userservice/global/config/redis/util/VisitorRedisUtil.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -14,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 public class VisitorRedisUtil {
 
     private final StringRedisTemplate redisTemplate;
+
 
     public void setData(String key, Object value, Long time, TimeUnit timeUnit) {
         redisTemplate.opsForValue().set(key, value.toString(), time, timeUnit);

--- a/src/test/java/com/example/userservice/domain/visitor/controller/VisitorControllerTest.java
+++ b/src/test/java/com/example/userservice/domain/visitor/controller/VisitorControllerTest.java
@@ -3,12 +3,14 @@ package com.example.userservice.domain.visitor.controller;
 import com.example.userservice.domain.member.dto.response.MemberLoginResponseDto;
 import com.example.userservice.domain.visitor.fixture.VisitorLocalDateTime;
 import com.example.userservice.domain.visitor.repository.VisitorRepository;
+import com.example.userservice.domain.visitor.service.VisitorService;
 import com.example.userservice.domain.visitor.util.ViewCountUtil;
 import com.example.userservice.global.config.redis.util.VisitorRedisUtil;
 import com.example.userservice.util.ControllerTestSupport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,8 @@ class VisitorControllerTest extends ControllerTestSupport {
 
         visitorRepository.deleteAllInBatch();
         visitorRedisUtil.deleteData("viewCount_Home_1"+year+month+day);
+        visitorRedisUtil.deleteData("ViewCount_Home_Total");
+
     }
 
     @DisplayName("메인 페이지에 접속하면 redis에서 조회수가 1회 증가한다.")
@@ -93,6 +97,31 @@ class VisitorControllerTest extends ControllerTestSupport {
 
         //then
         assertThat(viewCountUtil.getViewCount("viewCount_Home_1"+year+month+day)).isEqualTo(dataValue);
+    }
+
+    @DisplayName("메인페이지에 접속하면 총방문자 수를 조회할 수 있다.")
+    @Test
+    void enterMainPageThenReadTotalViewCount() throws Exception {
+        //given
+        String mockIp = "192.168.123.123";
+
+        visitorRedisUtil.increaseData("ViewCount_Home_Total");
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/visitor/total-view")
+                        .header("X-FORWARDED-FOR", mockIp)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String result = mvcResult.getResponse().getContentAsString();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(result);
+        int dataValue = jsonNode.get("data").asInt();
+
+        //then
+        assertThat(viewCountUtil.getViewCount("ViewCount_Home_Total")).isEqualTo(dataValue);
     }
 
 }

--- a/src/test/java/com/example/userservice/domain/visitor/controller/VisitorControllerTest.java
+++ b/src/test/java/com/example/userservice/domain/visitor/controller/VisitorControllerTest.java
@@ -1,0 +1,98 @@
+package com.example.userservice.domain.visitor.controller;
+
+import com.example.userservice.domain.member.dto.response.MemberLoginResponseDto;
+import com.example.userservice.domain.visitor.fixture.VisitorLocalDateTime;
+import com.example.userservice.domain.visitor.repository.VisitorRepository;
+import com.example.userservice.domain.visitor.util.ViewCountUtil;
+import com.example.userservice.global.config.redis.util.VisitorRedisUtil;
+import com.example.userservice.util.ControllerTestSupport;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class VisitorControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private VisitorRepository visitorRepository;
+
+    @Autowired
+    private ViewCountUtil viewCountUtil;
+    @Autowired
+    private VisitorRedisUtil visitorRedisUtil;
+
+    @AfterEach
+    void tearDown() {
+        int year = VisitorLocalDateTime.YEAR;
+        int month = VisitorLocalDateTime.MONTH;
+        int day = VisitorLocalDateTime.DAY;
+
+
+        visitorRepository.deleteAllInBatch();
+        visitorRedisUtil.deleteData("viewCount_Home_1"+year+month+day);
+    }
+
+    @DisplayName("메인 페이지에 접속하면 redis에서 조회수가 1회 증가한다.")
+    @Test
+    void increaseViewCount() throws Exception {
+        //given
+
+
+        int year = VisitorLocalDateTime.YEAR;
+        int month = VisitorLocalDateTime.MONTH;
+        int day = VisitorLocalDateTime.DAY;
+
+        String mockIp = "192.168.123.123";
+        //when
+        mockMvc.perform(post("/api/v1/visitor")
+                        .header("X-FORWARDED-FOR", mockIp)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //then
+        assertThat(viewCountUtil.getViewCount("viewCount_Home_1"+year+month+day)).isEqualTo(1);
+    }
+
+    @DisplayName("메인페이지에 접속하면 일일방문자 수를 조회할 수 있다.")
+    @Test
+    void enterMainPageThenReadTodayViewCount() throws Exception {
+        //given
+        String mockIp = "192.168.123.123";
+
+        int year = VisitorLocalDateTime.YEAR;
+        int month = VisitorLocalDateTime.MONTH;
+        int day = VisitorLocalDateTime.DAY;
+
+        visitorRedisUtil.increaseData("viewCount_Home_1"+year+month+day);
+
+        //when
+        MvcResult mvcResult = mockMvc.perform(get("/api/v1/visitor")
+                        .header("X-FORWARDED-FOR", mockIp)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String result = mvcResult.getResponse().getContentAsString();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(result);
+        int dataValue = jsonNode.get("data").asInt();
+
+        //then
+        assertThat(viewCountUtil.getViewCount("viewCount_Home_1"+year+month+day)).isEqualTo(dataValue);
+    }
+
+}

--- a/src/test/java/com/example/userservice/domain/visitor/entity/VisitorTest.java
+++ b/src/test/java/com/example/userservice/domain/visitor/entity/VisitorTest.java
@@ -1,0 +1,41 @@
+package com.example.userservice.domain.visitor.entity;
+
+import com.example.userservice.util.ControllerTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VisitorTest extends ControllerTestSupport {
+
+
+
+    @DisplayName("조회 수는 초기값이 0이다.")
+    @Test
+    void test(){
+
+        //when //given
+        Visitor visitor =new Visitor();
+
+
+        //then
+        assertThat(visitor.getCount()).isEqualTo(0);
+        assertThat(visitor.getId()).isZero();
+
+    }
+    @DisplayName("조회수 객체의 조회수는 더해진만큼 조회수가 증가한다.")
+    @Test
+    void plusViewCount() throws Exception {
+        //given
+        Visitor home = new Visitor(0);
+
+        //when
+        home.plus(10);
+
+        //then
+        assertThat(home.getCount()).isEqualTo(10);
+    }
+
+
+}

--- a/src/test/java/com/example/userservice/domain/visitor/fixture/VisitorLocalDateTime.java
+++ b/src/test/java/com/example/userservice/domain/visitor/fixture/VisitorLocalDateTime.java
@@ -1,0 +1,12 @@
+package com.example.userservice.domain.visitor.fixture;
+
+import java.time.LocalDateTime;
+
+public class VisitorLocalDateTime {
+
+    public final static LocalDateTime dateTime = LocalDateTime.now();
+    public final static int YEAR = dateTime.getYear();
+    public final static int MONTH = dateTime.getMonthValue();
+    public final static int DAY = dateTime.getDayOfMonth();
+
+}

--- a/src/test/java/com/example/userservice/domain/visitor/util/ViewCountUtilTest.java
+++ b/src/test/java/com/example/userservice/domain/visitor/util/ViewCountUtilTest.java
@@ -1,0 +1,56 @@
+package com.example.userservice.domain.visitor.util;
+
+import com.example.userservice.domain.visitor.fixture.VisitorLocalDateTime;
+import com.example.userservice.global.config.redis.util.VisitorRedisUtil;
+import com.example.userservice.util.ControllerTestSupport;
+import com.netflix.discovery.converters.Auto;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ViewCountUtilTest extends ControllerTestSupport {
+
+    @Autowired
+    private ViewCountUtil viewCountUtil;
+
+
+    @AfterEach
+    void tearDown() {
+        viewCountUtil.deleteData("ViewCount_Home_Total");
+    }
+
+    @DisplayName("redis에 데이터가 없을 경우에는 0을 반환한다.")
+    @Test
+    void readToDayViewCount(){
+        //when
+        Long viewCountHomeTotal = viewCountUtil.getViewCount("ViewCount_Home_Total");
+
+
+        //then
+        assertThat(viewCountHomeTotal).isEqualTo(0);
+
+
+
+    }
+
+    @DisplayName("redis에서 총 조회수를 증가시킨다.")
+    @Test
+    void increaseTotalViewCount(){
+
+        //given
+        viewCountUtil.increaseData("ViewCount_Home_Total");
+
+        //when
+        Long viewCountHomeTotal = viewCountUtil.getViewCount("ViewCount_Home_Total");
+        // then
+        
+        assertThat(viewCountHomeTotal).isEqualTo(1);
+
+
+    }
+
+}


### PR DESCRIPTION
## ✨ 요약
```
redis를 사용하여 일일 방문자 처리를 한다. 일일사용자처리는 LocalDateTime Asia/Seoul로 처리한다.
```

<br><br>

## 😎 해결한 이슈
- 원래 x-forwarded로 넘어온 클라이언트의 ip를 통해서 일일사용자 처리를 하려고했지만 kpaas-ta 클라우드에 내부에서 Istio서비스매시에서 127.0.06을 계속반환하는 문제가 발생(kpaas가 관리하는 서비스매쉬라 custom 불가능) -> 프론트엔드에서 23:59분까지 visited쿠키를 가지고 있도록 처리한 후 visitied쿠키가 없는 사용자만 조회수 카운트 처리를 하기로 결정함. 추후 ncloud로 migration작업을 할 때는 ip별로 처리하기

<br><br>