### PR TITLE
feat: subscribe interest keyword

### DIFF
--- a/src/main/java/com/example/userservice/domain/subscriber/controller/SubscriberController.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/controller/SubscriberController.java
@@ -1,15 +1,15 @@
 package com.example.userservice.domain.subscriber.controller;
 
 
-import com.example.userservice.domain.member.dto.response.CreateMemberResponseDto;
 import com.example.userservice.domain.subscriber.dto.request.SubscribeRequestDto;
 import com.example.userservice.domain.subscriber.service.SubscriberService;
-import com.example.userservice.global.common.CommonResDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,8 +20,8 @@ public class SubscriberController {
     private final SubscriberService subscriberService;
 
     @PostMapping("/subscribe")
-    public ResponseEntity<?> subscribe(@RequestBody SubscribeRequestDto subscribeRequestDto) {
-        subscriberService.subscribe(subscribeRequestDto.getEmail());
+    public ResponseEntity<?> subscribe(@Valid @RequestBody SubscribeRequestDto subscribeRequestDto) {
+        subscriberService.subscribe(subscribeRequestDto.getEmail(), subscribeRequestDto.getKeywords());
         return ResponseEntity.status(HttpStatus.CREATED).body("구독 완료: " + subscribeRequestDto.getEmail());
     }
 

--- a/src/main/java/com/example/userservice/domain/subscriber/dto/request/SubscribeRequestDto.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/dto/request/SubscribeRequestDto.java
@@ -3,8 +3,18 @@ package com.example.userservice.domain.subscriber.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.List;
+
 @NoArgsConstructor
 @Getter
 public class SubscribeRequestDto {
     private String email;
+
+    @Size(min=1, max = 3, message = "You must provide 1 to 3 keywords.")
+    private List<
+            @NotBlank(message = "Each keyword must not be blank.")
+            @Size(min = 2, max = 20, message = "Keyword must be between 2 and 20 characters.")
+                    String> keywords;
 }

--- a/src/main/java/com/example/userservice/domain/subscriber/dto/request/SubscribeRequestDto.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/dto/request/SubscribeRequestDto.java
@@ -1,20 +1,29 @@
 package com.example.userservice.domain.subscriber.dto.request;
 
+import com.example.userservice.domain.subscriber.dto.validator.ValidKeywords;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang.StringUtils;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @NoArgsConstructor
-@Getter
 public class SubscribeRequestDto {
+    @Getter
     private String email;
 
-    @Size(min=1, max = 3, message = "You must provide 1 to 3 keywords.")
-    private List<
-            @NotBlank(message = "Each keyword must not be blank.")
-            @Size(min = 2, max = 20, message = "Keyword must be between 2 and 20 characters.")
-                    String> keywords;
+    @ValidKeywords(minSize = 1, maxSize = 3, keywordMinLength = 2, keywordMaxLength = 20,
+            message = "Keywords must be 1~3, each 2~20 characters and unique.")
+    private List<String> keywords;
+
+    // 중복 제거
+    public List<String> getKeywords() {
+        return keywords.stream()
+                .map(String::trim)
+                .filter(StringUtils::isNotBlank)
+                .distinct()
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/userservice/domain/subscriber/dto/validator/KeywordsValidator.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/dto/validator/KeywordsValidator.java
@@ -5,9 +5,12 @@ import org.apache.commons.lang.StringUtils;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class KeywordsValidator implements ConstraintValidator<ValidKeywords, List<String>> {
+
+    private static final Pattern VALID_KEYWORD_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣 ]+$");
 
     private int minSize;
     private int maxSize;
@@ -26,7 +29,7 @@ public class KeywordsValidator implements ConstraintValidator<ValidKeywords, Lis
     public boolean isValid(List<String> value, ConstraintValidatorContext constraintValidatorContext) {
         if (value == null) return false;
 
-        List<String > processed = value.stream()
+        List<String> processed = value.stream()
                 .map(String::trim)
                 .filter(StringUtils::isNotBlank)
                 .distinct()
@@ -37,6 +40,8 @@ public class KeywordsValidator implements ConstraintValidator<ValidKeywords, Lis
         }
 
         return processed.stream()
-                .allMatch(s -> s.length() >= keywordMinLength && s.length() <= keywordMaxLength);
+                .allMatch(s -> s.length() >= keywordMinLength
+                        && s.length() <= keywordMaxLength
+                        && VALID_KEYWORD_PATTERN.matcher(s).matches());
     }
 }

--- a/src/main/java/com/example/userservice/domain/subscriber/dto/validator/KeywordsValidator.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/dto/validator/KeywordsValidator.java
@@ -1,0 +1,42 @@
+package com.example.userservice.domain.subscriber.dto.validator;
+
+import org.apache.commons.lang.StringUtils;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class KeywordsValidator implements ConstraintValidator<ValidKeywords, List<String>> {
+
+    private int minSize;
+    private int maxSize;
+    private int keywordMinLength;
+    private int keywordMaxLength;
+
+    @Override
+    public void initialize(ValidKeywords constraintAnnotation) {
+        this.minSize = constraintAnnotation.minSize();
+        this.maxSize = constraintAnnotation.maxSize();
+        this.keywordMinLength = constraintAnnotation.keywordMinLength();
+        this.keywordMaxLength = constraintAnnotation.keywordMaxLength();
+    }
+
+    @Override
+    public boolean isValid(List<String> value, ConstraintValidatorContext constraintValidatorContext) {
+        if (value == null) return false;
+
+        List<String > processed = value.stream()
+                .map(String::trim)
+                .filter(StringUtils::isNotBlank)
+                .distinct()
+                .collect(Collectors.toList());
+
+        if (processed.size() < minSize || processed.size() > maxSize) {
+            return false;
+        }
+
+        return processed.stream()
+                .allMatch(s -> s.length() >= keywordMinLength && s.length() <= keywordMaxLength);
+    }
+}

--- a/src/main/java/com/example/userservice/domain/subscriber/dto/validator/ValidKeywords.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/dto/validator/ValidKeywords.java
@@ -1,0 +1,23 @@
+package com.example.userservice.domain.subscriber.dto.validator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = KeywordsValidator.class)
+public @interface ValidKeywords {
+
+    String message() default "Invalid keywords.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    int minSize() default 1;
+    int maxSize() default 3;
+    int keywordMinLength() default 1;
+    int keywordMaxLength() default 200;
+}

--- a/src/main/java/com/example/userservice/domain/subscriber/entity/Interest.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/entity/Interest.java
@@ -1,0 +1,31 @@
+package com.example.userservice.domain.subscriber.entity;
+
+import com.example.userservice.global.entity.BaseTimeEntity;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Interest extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String keyword;
+
+    @ManyToOne
+    @JoinColumn(name = "subscriber_id")
+    private Subscriber subscriber;
+
+    public Interest(String keyword) {
+        this.keyword = keyword;
+    }
+
+    public void setSubscriber(Subscriber subscriber) {
+        this.subscriber = subscriber;
+    }
+}

--- a/src/main/java/com/example/userservice/domain/subscriber/entity/Subscriber.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/entity/Subscriber.java
@@ -2,11 +2,11 @@ package com.example.userservice.domain.subscriber.entity;
 
 import com.example.userservice.global.entity.BaseTimeEntity;
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
-import java.util.Objects;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -27,12 +27,30 @@ public class Subscriber extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean subscribed = true; // 구독 상태 (true: 구독 중, false: 구독 취소)
 
+    @OneToMany(mappedBy = "subscriber", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Interest> interests = new ArrayList<>();
+
     public Subscriber(String email) {
         this.email = email;
     }
 
+    public Subscriber(String email, List<String> keywords) {
+        this.email = email;
+
+        keywords.stream()
+                .distinct()
+                .map(Interest::new)
+                .forEach(this::add);
+    }
+
     public void unsubscribe() {
         this.subscribed = false;
+    }
+
+    // 연관관계 메서드
+    public void add(Interest interest) {
+        interests.add(interest);
+        interest.setSubscriber(this);
     }
 
 }

--- a/src/main/java/com/example/userservice/domain/subscriber/entity/Subscriber.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/entity/Subscriber.java
@@ -38,7 +38,6 @@ public class Subscriber extends BaseTimeEntity {
         this.email = email;
 
         keywords.stream()
-                .distinct()
                 .map(Interest::new)
                 .forEach(this::add);
     }

--- a/src/main/java/com/example/userservice/domain/subscriber/service/SubscriberService.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/service/SubscriberService.java
@@ -1,6 +1,8 @@
 package com.example.userservice.domain.subscriber.service;
 
+import java.util.List;
+
 public interface SubscriberService {
-    void subscribe(String email);
+    void subscribe(String email, List<String> keywords);
     void unsubscribe(String email);
 }

--- a/src/main/java/com/example/userservice/domain/subscriber/service/impl/SubscriberServiceImpl.java
+++ b/src/main/java/com/example/userservice/domain/subscriber/service/impl/SubscriberServiceImpl.java
@@ -1,6 +1,5 @@
 package com.example.userservice.domain.subscriber.service.impl;
 
-import com.example.userservice.domain.member.dto.request.SignUpRequestDto;
 import com.example.userservice.domain.subscriber.entity.Subscriber;
 import com.example.userservice.domain.subscriber.repository.SubscriberRepository;
 import com.example.userservice.domain.subscriber.service.SubscriberService;
@@ -25,15 +24,15 @@ public class SubscriberServiceImpl implements SubscriberService {
 
     @Override
     @Transactional
-    public void subscribe(String email) {
+    public void subscribe(String email, List<String> keywords) {
         // 이메일 중복 체크
         subscriberRepository.findByEmail(email).ifPresent(subscriber -> {
             throw new IllegalArgumentException("이미 구독된 이메일입니다.");
         });
         emailVerifyCheck(email);
 
-        // 새 구독자 저장
-        Subscriber subscriber = new Subscriber(email);
+        // 관심 키워드와 함께 새 구독자 저장
+        Subscriber subscriber = new Subscriber(email, keywords);
         subscriberRepository.save(subscriber);
     }
 


### PR DESCRIPTION
## ✨ 요약
## 관심 키워드 테이블 생성

### 키워드가 유니크하게 다대다로 해야할까?

```jsx
Table subscriber {
  subscriber_id bigint
  email varchar(255)
  subscribed bit(1)

  created_at datetime
  updated_at datatime
  deleted_at datetime 
}
// 이미 존재하는 테이블 

Table subscriber_interest {
  id bigint
  subscriber_id bigint 
  interest_id bigint

  created_at datetime
  updated_at datatime
  deleted_at datetime 
}

Table interest {
  id bigint
  keyword varchar(255)

  created_at datetime
  updated_at datetime
  deleted_at datetime
}

Ref: subscriber.subscriber_id < subscriber_interest.subscriber_id
Ref: interest.id < subscriber_interest.interest_id
 
```

> [[dbdiagrm.io](http://dbdiagrm.io/)](http://dbdiagrm.io) script
> 

![image](https://github.com/user-attachments/assets/a35949a9-d117-4595-bfe0-7b247c5e356f)


```sql
CREATE TABLE interest (
  id BIGINT PRIMARY KEY,
  keyword VARCHAR(255),
  created_at DATETIME,
  updated_at DATETIME,
  deleted_at DATETIME
);

CREATE TABLE subscriber_interest (
  id BIGINT PRIMARY KEY,
  subscriber_id BIGINT,
  interest_id BIGINT,
  created_at DATETIME,
  updated_at DATETIME,
  deleted_at DATETIME,
  FOREIGN KEY (subscriber_id) REFERENCES subscriber(subscriber_id),
  FOREIGN KEY (interest_id) REFERENCES interest(id)
);
```

> mysql DDL
> 

### 키워드 글자가 중요한 것이니, 편의를 위해 일대다로 할까?

```jsx
 Table subscriber {
  subscriber_id bigint
  email varchar(255)
  subscribed bit(1)

  created_at datetime
  updated_at datatime
  deleted_at datetime 
}
// 이전에 있던 테이블

// Table subscriber_interest {
//   id bigint
//   subscriber_id bigint 
//   interest_id bigint

//   created_at datetime
//   updated_at datatime
//   deleted_at datetime 
// }

Table interest {
  id bigint
  keyword varchar(255)
  subscriber_id bigint 

  created_at datetime
  updated_at datetime
  deleted_at datetime
}

Ref: subscriber.subscriber_id < interest.subscriber_id
```

> [dbdiagram.io](http://dbdiagram.io/)
> 

![image](https://github.com/user-attachments/assets/e90dab6a-6644-463e-83c5-9edf1a0f8e18)


```sql

CREATE TABLE interest (
  id BIGINT PRIMARY KEY,
  keyword VARCHAR(255),
  subscriber_id BIGINT,
  created_at DATETIME,
  updated_at DATETIME,
  deleted_at DATETIME,
  FOREIGN KEY (subscriber_id) REFERENCES subscriber(subscriber_id)
);
```

> mysql DDL
> 

- **결론: 일단은 개발 편의를 위해 일대다로 진행**
    - **키워드 글자만 중요하다고 판단하였기 때문**
    - **키워드 글자를 가지고 API 호출 시 쿼리 스트링으로 사용**

## 엔티티 매핑

[**[How does JPA orphanRemoval=true differ from the ON DELETE CASCADE DML clause](https://stackoverflow.com/questions/4329577/how-does-jpa-orphanremoval-true-differ-from-the-on-delete-cascade-dml-clause)**](https://stackoverflow.com/questions/4329577/how-does-jpa-orphanremoval-true-differ-from-the-on-delete-cascade-dml-clause)

- Subscriber

```java
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Entity
@Table(name = "SUBSCRIBER")
@Builder
@AllArgsConstructor
public class Subscriber extends BaseTimeEntity {

    // ...

    @OneToMany(mappedBy = "subscriber", cascade = CascadeType.ALL, orphanRemoval = true)
    private List<Interest> interests = new ArrayList<>();

    public Subscriber(String email, List<String> keywords) {
        this.email = email;

        keywords.stream()
                .map(Interest::new)
                .forEach(this::add);
    }

    public void add(Interest interest) {
        interests.add(interest);
        interest.setSubscriber(this);
    }

```

- Interest

```java
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Entity
@Builder
@AllArgsConstructor
public class Interest extends BaseTimeEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(nullable = false)
    private String keyword;

    @ManyToOne
    @JoinColumn(name = "subscriber_id")
    private Subscriber subscriber;

    public void setSubscriber(Subscriber subscriber) {
        this.subscriber = subscriber;
    }
}
```

## 기능 추가

- API request 변경

```java
@NoArgsConstructor
@Getter
public class SubscribeRequestDto {
    private String email;

    @Size(min=1, max = 3, message = "You must provide 1 to 3 keywords.")
    private List<
            @NotBlank(message = "Each keyword must not be blank.")
            @Size(min = 2, max = 20, message = "Keyword must be between 2 and 20 characters.")
                    String> keywords;
    // keywords List 추가 
}
```

- service에 저장 로직 수정

```java
    @Override
    @Transactional
    public void subscribe(String email, List<String> keywords) {
        // 이메일 중복 체크
        subscriberRepository.findByEmail(email).ifPresent(subscriber -> {
            throw new IllegalArgumentException("이미 구독된 이메일입니다.");
        });
        emailVerifyCheck(email);

        // 관심 키워드와 함께 새 구독자 저장
        Subscriber subscriber = new Subscriber(email, keywords);
        subscriberRepository.save(subscriber);
    }
```

> 신규 구독 시에만 타는 로직이라 판단해서, 현재 subscirber가 갖고있는 keyword 개수 안셈
- keyword 개수는 당연히 0개니까 (new)
> 

 

## 기능 구현 테스트

email: “kbsserver@naver.com” 

- [x]  API request 바뀐대로 잘 받는지
- [x]  3개 이상 키워드는 예외 던지는 지
    - [x]  각 키워드의 글자수 제한이 잘 걸리는지 2~20자
- [x]  빈 키워드도 예외 던지는지
- [x]  키워드 중복 제거 잘 되는지
- [x]  구독자의 관심 키워드가 연관관계로 잘 들어가서 DB에 저장되었는지

## 추가 커밋 이유 

![image](https://github.com/user-attachments/assets/763f4631-adcc-4af6-90e4-89ef6582c0ed)

- 한 글자는 사용 못하도록 검증 애노테이션 달았지만, “  a “ 와 같이 빈칸과 같이 오면 통과함
- **내가 원하는 궁극적인 검증은 입력으로 들어온 것들의 중복을 제거하고, trim을 모두 적용한 뒤 검증 로직을 적용했으면 좋겠음**

## 해결

- 직접 Validator 구현

- validator

```java
public class KeywordsValidator implements ConstraintValidator<ValidKeywords, List<String>> {

    private int minSize;
    private int maxSize;
    private int keywordMinLength;
    private int keywordMaxLength;

    @Override
    public void initialize(ValidKeywords constraintAnnotation) {
        this.minSize = constraintAnnotation.minSize();
        this.maxSize = constraintAnnotation.maxSize();
        this.keywordMinLength = constraintAnnotation.keywordMinLength();
        this.keywordMaxLength = constraintAnnotation.keywordMaxLength();
    }

    @Override
    public boolean isValid(List<String> value, ConstraintValidatorContext constraintValidatorContext) {
        if (value == null) return false;

        List<String > processed = value.stream()
                .map(String::trim)
                .filter(StringUtils::isNotBlank)
                .distinct()
                .collect(Collectors.toList());

        if (processed.size() < minSize || processed.size() > maxSize) {
            return false;
        }

        return processed.stream()
                .allMatch(s -> s.length() >= keywordMinLength && s.length() <= keywordMaxLength);
    }
}
```

> 원래 리스트를 순회한김에 변환하여 반환하려고 했음
> 
> 
> 그러나, 검증용 애노테이션이 실제 필드값을 변환시킨다는 것이 추후 이해하기 힘들 것 같아 해당 부분 제거 
> 
> 실제로 많아봐야 3개정도라서 dto에서 getter를 호출할 때 중복값 제거 및 trim을 해줘도 된다고 생각했음 
> 

- valid annotation

```java
@Target({ElementType.FIELD})
@Retention(RetentionPolicy.RUNTIME)
@Constraint(validatedBy = KeywordsValidator.class)
public @interface ValidKeywords {

    String message() default "Invalid keywords.";
    Class<?>[] groups() default {};
    Class<? extends Payload>[] payload() default {};

    int minSize() default 1;
    int maxSize() default 3;
    int keywordMinLength() default 1;
    int keywordMaxLength() default 200;
}
```

- API request dto

```java
@NoArgsConstructor
public class SubscribeRequestDto {
    @Getter
    private String email;

    @ValidKeywords(minSize = 1, maxSize = 3, keywordMinLength = 2, keywordMaxLength = 20,
            message = "Keywords must be 1~3, each 2~20 characters and unique.")
    private List<String> keywords;

    // 중복 제거
    public List<String> getKeywords() {
        return keywords.stream()
                .map(String::trim)
                .filter(StringUtils::isNotBlank)
                .distinct()
                .collect(Collectors.toList());
    }
}
```

- 체크리스트
- [x]  “ab”, “   b” 실패
- [x]  “ab”, “      ab ”  get 결과는 “ab” 한개
- [x]  “abc”, “  abc ”, “abc”, “bb”, “cc” 가능 (중복제거를 통해 총 3개)

## 추가로 할 것

- 현재 API request 검증에 걸리는 경우, 예외 메시지(argumentNotValidException) 그냥 던지고 있는데 원하는 에러 형식이 있으면 맞춰서 드리겠습니다.
    
![image](https://github.com/user-attachments/assets/6faf212f-2119-4884-bd63-342535e4f4c6)

<br><br>

## 😎 해결한 이슈
[[✨ feat] 관심 키워드 알림 서비스 #48](https://github.com/flowbit-team/USER_SERVICE_MSA/issues/48)

<br><br>

 ## 궁금증

- UserService API 스펙이 바뀌었는데, Swagger 설정 따로 해줘야하는지?
- API 명세서는 어디서 볼 수 있는지?
- POSTMAN 연동되는지
- LIVE RELOAD 같은 거 해놓으신건지